### PR TITLE
Added max version constraint for numpy

### DIFF
--- a/requirements/requirements.gpu-cu90.txt
+++ b/requirements/requirements.gpu-cu90.txt
@@ -1,4 +1,4 @@
 pyyaml==3.12
 mxnet-cu90mkl==1.2.0
-numpy>=1.12
+numpy>=1.12,<1.15.0
 typing


### PR DESCRIPTION
Added ",<1.15.0" to numpy constraints as otherwise sockeye does not install.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

